### PR TITLE
Fixed crash on start with Sublime Text 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Features
 - Upload to FTP server on local file save
 - Higly configurable
-- Auto creates directory if doesn't exists on server and auto delete files on local file delete (configurable; **BETA** - Please report any issues. If any problem occured, you can disable delete handler patching by setting `"enableDeleteHandler"` option to false in global settings (`Preferences -> Package Settings -> Simple FTP Deploy -> Settings - User`) and restarting Sublime Text)
+- Auto creates directory if doesn't exists on server
 
 ## How to Install
 

--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ class Ftp(object):
 		start = time.time()
 
 		fullFtpPath, currentFileName = self.parsePath(localRootDir, currentFullPath)
-		
+
 		if fullFtpPath == '':
 			fullFtpPath = '/'
 
@@ -242,7 +242,12 @@ class SaveEventListener(sublime_plugin.EventListener):
 # To disable this feature, please set `enableDeleteHandler` setting to false in global settings
 # WARNING: HIGHLY EXPERIMENTAL, OVERRIDES DEFAULT DELETE HANDLERS (imported from side_bar.py from Default.sublime-package)
 # ==============
-if sublime.load_settings("simple-ftp-deploy.sublime-settings").get("enableDeleteHandler", True):
+
+# Disabled as it causes issues on Sublime Text 4
+
+ST = 3000 if sublime.version() == '' else int(sublime.version())
+
+if sublime.load_settings("simple-ftp-deploy.sublime-settings").get("enableDeleteHandler", False) and ST < 4000:
 	from Default.side_bar import *
 	import functools
 

--- a/main.py
+++ b/main.py
@@ -247,7 +247,7 @@ class SaveEventListener(sublime_plugin.EventListener):
 
 ST = 3000 if sublime.version() == '' else int(sublime.version())
 
-if sublime.load_settings("simple-ftp-deploy.sublime-settings").get("enableDeleteHandler", False) and ST < 4000:
+if sublime.load_settings("simple-ftp-deploy.sublime-settings").get("enableDeleteHandler", False) and ST <= 4000:
 	from Default.side_bar import *
 	import functools
 

--- a/simple-ftp-deploy.sublime-settings
+++ b/simple-ftp-deploy.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"enableDeleteHandler": true
+	"enableDeleteHandler": false
 }


### PR DESCRIPTION
I am sorry, but I did not used FTP for a while, so I did not noticed that my deleteFileCommand patch started to crash on Sublime Text 4. But since I firstly created that patch to add feature to automatically delete files on FTP too, I found better way to implement it without needing to patch, using `on_post_window_command` or  `on_post_text_command`, which I will try to implement in near future and also add other handlers than delete, but for now, I disabled deleteHandler in settings, and in main.py if Sublime Text version is greater than 4000, to make it work...

Before that is merged, you can set  `"enableDeleteHandler"` option to `false` in global settings (`Preferences -> Package Settings -> Simple FTP Deploy -> Settings - User`)

Fixes #11 
Fixes #13